### PR TITLE
More ZOffset fixes

### DIFF
--- a/OpenRA.Mods.Common/Effects/Bullet.cs
+++ b/OpenRA.Mods.Common/Effects/Bullet.cs
@@ -63,6 +63,7 @@ namespace OpenRA.Mods.Common.Effects
 		public readonly bool TrailUsePlayerPalette = false;
 
 		public readonly int ContrailLength = 0;
+		public readonly int ContrailZOffset = 2047;
 		public readonly Color ContrailColor = Color.White;
 		public readonly bool ContrailUsePlayerColor = false;
 		public readonly int ContrailDelay = 1;
@@ -128,7 +129,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (info.ContrailLength > 0)
 			{
 				var color = info.ContrailUsePlayerColor ? ContrailRenderable.ChooseColor(args.SourceActor) : info.ContrailColor;
-				contrail = new ContrailRenderable(world, color, info.ContrailWidth, info.ContrailLength, info.ContrailDelay, 0);
+				contrail = new ContrailRenderable(world, color, info.ContrailWidth, info.ContrailLength, info.ContrailDelay, info.ContrailZOffset);
 			}
 
 			trailPalette = info.TrailPalette;

--- a/OpenRA.Mods.Common/Effects/Contrail.cs
+++ b/OpenRA.Mods.Common/Effects/Contrail.cs
@@ -23,6 +23,9 @@ namespace OpenRA.Mods.Common.Effects
 		[Desc("Position relative to body")]
 		public readonly WVec Offset = WVec.Zero;
 
+		[Desc("Offset for Z sorting.")]
+		public readonly int ZOffset = 0;
+
 		[Desc("Length of the trail (in ticks).")]
 		public readonly int TrailLength = 25;
 
@@ -51,7 +54,7 @@ namespace OpenRA.Mods.Common.Effects
 			this.info = info;
 
 			var color = info.UsePlayerColor ? ContrailRenderable.ChooseColor(self) : info.Color;
-			trail = new ContrailRenderable(self.World, color, info.TrailWidth, info.TrailLength, 0, 0);
+			trail = new ContrailRenderable(self.World, color, info.TrailWidth, info.TrailLength, 0, info.ZOffset);
 
 			body = self.Trait<BodyOrientation>();
 		}

--- a/OpenRA.Mods.Common/Effects/Missile.cs
+++ b/OpenRA.Mods.Common/Effects/Missile.cs
@@ -105,6 +105,8 @@ namespace OpenRA.Mods.Common.Effects
 
 		public readonly int ContrailLength = 0;
 
+		public readonly int ContrailZOffset = 2047;
+
 		public readonly WDist ContrailWidth = new WDist(64);
 
 		public readonly Color ContrailColor = Color.White;
@@ -211,7 +213,7 @@ namespace OpenRA.Mods.Common.Effects
 			if (info.ContrailLength > 0)
 			{
 				var color = info.ContrailUsePlayerColor ? ContrailRenderable.ChooseColor(args.SourceActor) : info.ContrailColor;
-				contrail = new ContrailRenderable(world, color, info.ContrailWidth, info.ContrailLength, info.ContrailDelay, 0);
+				contrail = new ContrailRenderable(world, color, info.ContrailWidth, info.ContrailLength, info.ContrailDelay, info.ContrailZOffset);
 			}
 
 			trailPalette = info.TrailPalette;

--- a/mods/d2k/sequences/misc.yaml
+++ b/mods/d2k/sequences/misc.yaml
@@ -271,6 +271,8 @@ fire:
 		BlendMode: Additive
 
 smoke_m:
+	Defaults:
+		ZOffset: 511
 	idle: DATA.R8
 		Start: 3418
 		Length: 2

--- a/mods/ts/sequences/misc.yaml
+++ b/mods/ts/sequences/misc.yaml
@@ -268,6 +268,7 @@ emp:
 	idle: emp_fx01
 		Length: *
 		BlendMode: Additive
+		ZOffset: 2047
 
 resources:
 	Defaults:


### PR DESCRIPTION
These _should_ be the last ones.

The Contrail trait is usually used by aircraft, so under normal circumstances a custom ZOffset shouldn't be necessary, but I made it customizable just in case.
